### PR TITLE
Update spark to v3.4.2

### DIFF
--- a/library/spark
+++ b/library/spark
@@ -41,6 +41,26 @@ Architectures: amd64, arm64v8
 GitCommit: 028efd4637fb2cf791d5bd9ea70b2fca472de4b7
 Directory: ./3.5.0/scala2.12-java11-python3-r-ubuntu
 
+Tags: 3.4.2-scala2.12-java11-python3-ubuntu, 3.4.2-python3, 3.4.2
+Architectures: amd64, arm64v8
+GitCommit: 431aa516ba58985c902bf2d2a07bf0eaa1df6740
+Directory: ./3.4.2/scala2.12-java11-python3-ubuntu
+
+Tags: 3.4.2-scala2.12-java11-r-ubuntu, 3.4.2-r
+Architectures: amd64, arm64v8
+GitCommit: 431aa516ba58985c902bf2d2a07bf0eaa1df6740
+Directory: ./3.4.2/scala2.12-java11-r-ubuntu
+
+Tags: 3.4.2-scala2.12-java11-ubuntu, 3.4.2-scala
+Architectures: amd64, arm64v8
+GitCommit: 431aa516ba58985c902bf2d2a07bf0eaa1df6740
+Directory: ./3.4.2/scala2.12-java11-ubuntu
+
+Tags: 3.4.2-scala2.12-java11-python3-r-ubuntu
+Architectures: amd64, arm64v8
+GitCommit: 431aa516ba58985c902bf2d2a07bf0eaa1df6740
+Directory: ./3.4.2/scala2.12-java11-python3-r-ubuntu
+
 Tags: 3.4.1-scala2.12-java11-python3-ubuntu, 3.4.1-python3, 3.4.1
 Architectures: amd64,arm64v8
 GitCommit: 58d288546e8419d229f14b62b6a653999e0390f1


### PR DESCRIPTION
This patch add 3.4.2 version for Apache Spark https://spark.apache.org/docs/3.4.2/ [1]

[1] https://github.com/apache/spark-website/pull/491
[2] https://github.com/apache/spark-docker/pull/57
